### PR TITLE
fix(gallery): per-app SAVE button now actually downloads the HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -4193,7 +4193,7 @@
                 <button class="preview-button" onclick="previewTool('${tool.path || tool.filename}', '${tool.title}')">PREVIEW</button>
                 <button class="share-button" onclick="shareTool('${tool.path || tool.filename}', '${tool.title.replace(/'/g, "\\'")}', event)" title="Share via QR Code">SHARE</button>
                 <button class="vote-button ${hasVoted ? 'voted' : ''}" onclick="voteTool('${tool.filename}', event)">${hasVoted ? 'VOTED' : 'VOTE'}</button>
-                <button class="download-button" onclick="downloadTool('${tool.path || tool.filename}')">↓</button>
+                <button class="download-button" onclick="downloadTool('${tool.path || tool.filename}')" title="Save the HTML file for offline use">↓ SAVE</button>
             </div>
         `;
 
@@ -4424,13 +4424,33 @@
             filterAndDisplayTools();
         }
 
-        // Download tool
-        function downloadTool(path) {
-            const link = document.createElement('a');
-            link.href = path;
-            // Extract just the filename for the download attribute
-            link.download = path.split('/').pop();
-            link.click();
+        // Download tool — fetch the HTML, wrap in a Blob so the browser
+        // honors the download attribute even for same-origin text/html
+        // (which would otherwise navigate-instead-of-download).
+        async function downloadTool(path) {
+            const filename = path.split('/').pop();
+            try {
+                showNotification('Saving ' + filename + '…');
+                const response = await fetch(path);
+                if (!response.ok) {
+                    throw new Error('HTTP ' + response.status);
+                }
+                const html = await response.text();
+                const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = filename;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                // Revoke after the click completes; some browsers need a tick.
+                setTimeout(() => URL.revokeObjectURL(url), 100);
+                showNotification('Saved ' + filename, 'success');
+            } catch (e) {
+                console.error('Download failed:', e);
+                showNotification('Download failed: ' + (e.message || e), 'error');
+            }
         }
 
         // Toggle pin


### PR DESCRIPTION
## What

The '↓' button on each gallery card looked like a download button but didn't download — clicking it OPENED the app in a new tab.

## Why

Two issues:

1. **The label '↓' is too subtle** — easy to miss when scanning the row of OPEN/PREVIEW/SHARE/VOTE/↓ buttons.
2. **`<a download>` doesn't work for same-origin text/html.** Browsers ignore the download attribute and navigate to the URL instead. The current implementation:

   ```js
   function downloadTool(path) {
       const link = document.createElement('a');
       link.href = path;
       link.download = path.split('/').pop();
       link.click();
   }
   ```

   Works fine for cross-origin URLs and non-HTML files. Doesn't work for the 920 same-origin .html files in this repo.

## Fix

Use **fetch + Blob** so the browser is forced to treat the response as a downloadable attachment, regardless of MIME type or origin:

```js
async function downloadTool(path) {
    const filename = path.split('/').pop();
    try {
        showNotification('Saving ' + filename + '…');
        const response = await fetch(path);
        const html = await response.text();
        const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
        const url = URL.createObjectURL(blob);
        const link = document.createElement('a');
        link.href = url; link.download = filename;
        document.body.appendChild(link); link.click(); document.body.removeChild(link);
        setTimeout(() => URL.revokeObjectURL(url), 100);
        showNotification('Saved ' + filename, 'success');
    } catch (e) {
        showNotification('Download failed: ' + e.message, 'error');
    }
}
```

And re-label `↓` → `↓ SAVE` with a tooltip `Save the HTML file for offline use`. The save action is the headline value-prop of local-first tools — it should be discoverable.

## Note

This contradicts a decision I made earlier (in the smart-merge PR I noted 'all 732 paths are relative; origin's simple a.href = path works for every entry'). That conclusion was wrong — relative-path-but-same-origin-html is exactly the case where browsers ignore the download attribute. The user reported it the moment they tried to use it on the live site.

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot)