### PR TITLE
fix: 9 more bugs surfaced by health-check (pass rate 85% → 92%)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 .DS_Store
 Thumbs.db
 .worktrees/
+node_modules/
+

--- a/apps/creative/dune-symphony.html
+++ b/apps/creative/dune-symphony.html
@@ -52,18 +52,19 @@
         const canvas = document.getElementById('canvas');
         const ctx = canvas.getContext('2d');
         let W, H;
-        function resize() { W = canvas.width = innerWidth; H = canvas.height = innerHeight; initTerrain(); }
-        resize(); window.onresize = resize;
-
+        // === State declared BEFORE resize() — fixes TDZ on cols ===
+        const cols = 200;
+        let cellWidth;
+        let terrain = [];
+        let particles = [];
         let audioCtx = null;
         let soundEnabled = false;
         let windSpeed = 0.5;
         let windDir = Math.PI / 2;
         let grainDensity = 2;
-        let terrain = [];
-        let particles = [];
-        const cols = 200;
-        let cellWidth;
+
+        function resize() { W = canvas.width = innerWidth; H = canvas.height = innerHeight; initTerrain(); }
+        resize(); window.onresize = resize;
 
         function initAudio() {
             audioCtx = new (window.AudioContext || window.webkitAudioContext)();

--- a/apps/creative/magnetic-field-painter.html
+++ b/apps/creative/magnetic-field-painter.html
@@ -67,16 +67,16 @@
         // which used to be declared further down and tripped a TDZ error.
         const poles = [];
         const filings = [];
-        function resize() { W = canvas.width = innerWidth; H = canvas.height = innerHeight; initFilings(); }
-        resize(); window.onresize = resize;
-        
         let particleCount = 2000;
         let fieldStrength = 0.5;
         let currentPole = 'north';
         let showFieldLines = false;
         let time = 0;
-        
-        // (poles & filings declared above the resize() call — was TDZ-broken)
+
+        function resize() { W = canvas.width = innerWidth; H = canvas.height = innerHeight; if (typeof Filing !== 'undefined') initFilings(); }
+        window.onresize = resize;
+
+        // (state declared above; resize() actual call deferred until after the Filing class — see end of script)
 
         class Pole {
             constructor(x, y, type) {
@@ -328,6 +328,9 @@
         
         initFilings();
         animate();
-    </script>
+    
+        // Now that Filing class is declared, kick off the initial sizing
+        resize();
+        </script>
 </body>
 </html>

--- a/apps/development/time-travel-editor.html
+++ b/apps/development/time-travel-editor.html
@@ -316,7 +316,7 @@
 <html>
 <head>
     <title>Stage 2: 3D Setup</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"><\/script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.150.0/build/three.min.js"><\/script>
     <style>body { margin: 0; overflow: hidden; }</style>
 </head>
 <body>
@@ -351,7 +351,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PalBoids 3D: Swarm Collector</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"><\/script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.150.0/build/three.min.js"><\/script>
     <style>
         body { margin: 0; overflow: hidden; background-color: #0f172a; font-family: sans-serif; color: #e2e8f0; user-select: none; }
         #ui-layer { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }

--- a/apps/uncategorized/data-structures-visualizer.html
+++ b/apps/uncategorized/data-structures-visualizer.html
@@ -146,7 +146,7 @@
             canvas.height = canvas.parentElement.clientHeight;
             render();
         }
-        resize();
+        // (initial resize() deferred until after dataStructures const init — was TDZ-broken)
         window.addEventListener('resize', resize);
 
         const dataStructures = {
@@ -400,6 +400,9 @@
                 }
             }
         };
+
+        // Now safe to call — dataStructures is initialized
+        resize();
 
         function render() {
             dataStructures[currentDS].draw();

--- a/apps/utilities/bothangles-ios-fixed.html
+++ b/apps/utilities/bothangles-ios-fixed.html
@@ -950,13 +950,28 @@
       }, 1500);
     });
     
-    // Initialize frame buffers
+    // Initialize frame buffers — circular ring of canvases that hold recent webcam frames.
+    // FRAME_BUFFER_SIZE was undefined in the original (year-old bug); a value of 5 is a
+    // reasonable default that keeps memory bounded. If a #frameBufferN canvas isn't in the
+    // DOM (it isn't in the current markup), we create it offscreen at the expected size.
+    const FRAME_BUFFER_SIZE = 5;
+    let frameBuffers = [];
+    let frameTextures = [];
+    let frameIndex = 0;
     function initFrameBuffers() {
       for (let i = 0; i < FRAME_BUFFER_SIZE; i++) {
-        const canvas = document.getElementById(`frameBuffer${i}`);
+        let canvas = document.getElementById(`frameBuffer${i}`);
+        if (!canvas) {
+          canvas = document.createElement('canvas');
+          canvas.id = `frameBuffer${i}`;
+          canvas.width = 640;
+          canvas.height = 480;
+          canvas.style.display = 'none';
+          document.body.appendChild(canvas);
+        }
         const ctx = canvas.getContext('2d');
         frameBuffers.push({ canvas, ctx });
-        
+
         const texture = new THREE.CanvasTexture(canvas);
         texture.minFilter = THREE.LinearFilter;
         texture.magFilter = THREE.LinearFilter;

--- a/data/reports/health-check-latest.json
+++ b/data/reports/health-check-latest.json
@@ -1,54 +1,54 @@
 {
   "format": "localFirstTools-health-v1",
-  "generatedAt": "2026-05-04T02:12:42.735Z",
+  "generatedAt": "2026-05-04T02:40:06.266Z",
   "scope": "featured",
-  "timeoutMs": 12000,
+  "timeoutMs": 8000,
   "settleMs": 1500,
   "summary": {
     "total": 100,
-    "pass": 85,
-    "fail": 15,
-    "avgMs": 4211,
+    "pass": 92,
+    "fail": 8,
+    "avgMs": 2784,
     "slowestN": [
       {
+        "path": "exhibitions/visual-arts/nexus.html",
+        "ms": 8133
+      },
+      {
         "path": "exhibitions/visual-arts/pipboy-interface.html",
-        "ms": 12877
+        "ms": 8057
       },
       {
         "path": "exhibitions/visual-arts/downloaded.html",
-        "ms": 12254
+        "ms": 5796
       },
       {
-        "path": "exhibitions/visual-arts/nexus.html",
-        "ms": 12120
+        "path": "exhibitions/simulation-lab/index_slim_cloud.html",
+        "ms": 4776
+      },
+      {
+        "path": "exhibitions/visual-arts/severance-refiner.html",
+        "ms": 4448
       },
       {
         "path": "v2/apps/creative_tools/time-travel-editor.html",
-        "ms": 9160
-      },
-      {
-        "path": "exhibitions/visual-arts/vector-drawing-studio.html",
-        "ms": 8801
-      },
-      {
-        "path": "exhibitions/visual-arts/youtube-webcam-sync-fixed.html",
-        "ms": 8696
-      },
-      {
-        "path": "apps/simulations/ant-farm-simulation.html",
-        "ms": 7692
-      },
-      {
-        "path": "apps/business/personal-finance-dashboard.html",
-        "ms": 6647
-      },
-      {
-        "path": "exhibitions/simulation-lab/tile-room-3d.html",
-        "ms": 6641
+        "ms": 3827
       },
       {
         "path": "exhibitions/simulation-lab/workshop.html",
-        "ms": 6614
+        "ms": 3813
+      },
+      {
+        "path": "apps/uncategorized/ant-farm-3d.html",
+        "ms": 3558
+      },
+      {
+        "path": "v2/apps/creative_tools/narrative-multiverse.html",
+        "ms": 3423
+      },
+      {
+        "path": "fluid-cathedral.html",
+        "ms": 3404
       }
     ]
   },
@@ -59,10 +59,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 7692,
+      "ms": 2900,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:32.095Z"
+      "timestamp": "2026-05-04T02:39:53.615Z"
     },
     {
       "path": "exhibitions/simulation-lab/3d-engine-v6-graphics.html",
@@ -70,10 +70,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 4476,
+      "ms": 2619,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:29.592Z"
+      "timestamp": "2026-05-04T02:39:54.109Z"
     },
     {
       "path": "apps/simulations/evolution-simulator-3d.html",
@@ -81,10 +81,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 5191,
+      "ms": 2597,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:30.495Z"
+      "timestamp": "2026-05-04T02:39:54.498Z"
     },
     {
       "path": "exhibitions/simulation-lab/feedShyworm4.html",
@@ -92,10 +92,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 4974,
+      "ms": 2809,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:34.389Z"
+      "timestamp": "2026-05-04T02:39:56.466Z"
     },
     {
       "path": "exhibitions/simulation-lab/snake3.html",
@@ -103,10 +103,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 3347,
+      "ms": 2593,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:30.821Z"
+      "timestamp": "2026-05-04T02:39:55.097Z"
     },
     {
       "path": "exhibitions/simulation-lab/3d-engine-v1-minimal.html",
@@ -114,26 +114,21 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 3676,
+      "ms": 2657,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:33.388Z"
+      "timestamp": "2026-05-04T02:39:56.790Z"
     },
     {
       "path": "exhibitions/simulation-lab/3d-engine-v8-modular.html",
       "title": "3D Multiplayer Game Engine - Modular Architecture",
       "category": "3d_immersive",
       "featured": true,
-      "verdict": "fail",
-      "ms": 3645,
-      "errors": [
-        {
-          "kind": "pageerror",
-          "msg": "obj.mesh.quaternion.copy is not a function\nhttp://localhost:8765/exhibitions/simulation-lab/3d-engine-v8-modular.html:2610:45"
-        }
-      ],
+      "verdict": "pass",
+      "ms": 2572,
+      "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:34.233Z"
+      "timestamp": "2026-05-04T02:39:57.124Z"
     },
     {
       "path": "exhibitions/simulation-lab/3d-engine-v7-network.html",
@@ -141,10 +136,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 3505,
+      "ms": 2624,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:34.635Z"
+      "timestamp": "2026-05-04T02:39:57.751Z"
     },
     {
       "path": "exhibitions/simulation-lab/3d-engine-v5-physics.html",
@@ -152,10 +147,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 3201,
+      "ms": 2577,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:34.733Z"
+      "timestamp": "2026-05-04T02:39:59.090Z"
     },
     {
       "path": "exhibitions/simulation-lab/pokemon-generator-full-html.html",
@@ -163,10 +158,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 4023,
+      "ms": 2568,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:36.297Z"
+      "timestamp": "2026-05-04T02:39:59.515Z"
     },
     {
       "path": "exhibitions/simulation-lab/tile-room-3d.html",
@@ -174,10 +169,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 6641,
+      "ms": 2563,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:40.140Z"
+      "timestamp": "2026-05-04T02:39:59.784Z"
     },
     {
       "path": "apps/uncategorized/tesseract-4d-rotator.html",
@@ -185,10 +180,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 5699,
+      "ms": 2558,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:39.981Z"
+      "timestamp": "2026-05-04T02:40:00.341Z"
     },
     {
       "path": "apps/productivity/accordion-memories.html",
@@ -196,10 +191,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 2904,
+      "ms": 2326,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:39.256Z"
+      "timestamp": "2026-05-04T02:40:02.705Z"
     },
     {
       "path": "exhibitions/simulation-lab/workshop.html",
@@ -207,10 +202,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 6614,
+      "ms": 3813,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:41.011Z"
+      "timestamp": "2026-05-04T02:40:02.919Z"
     },
     {
       "path": "exhibitions/simulation-lab/index_slim_cloud.html",
@@ -218,10 +213,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 5995,
+      "ms": 4776,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:40.682Z"
+      "timestamp": "2026-05-04T02:40:04.360Z"
     },
     {
       "path": "exhibitions/simulation-lab/apex-protocol-v3f-polish.html",
@@ -229,10 +224,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 5745,
+      "ms": 2958,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:40.927Z"
+      "timestamp": "2026-05-04T02:40:02.798Z"
     },
     {
       "path": "exhibitions/simulation-lab/drone-simulator.html",
@@ -240,10 +235,10 @@
       "category": "3d_immersive",
       "featured": true,
       "verdict": "pass",
-      "ms": 2943,
+      "ms": 2583,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:42.275Z"
+      "timestamp": "2026-05-04T02:40:05.348Z"
     },
     {
       "path": "exhibitions/visual-arts/index2.html",
@@ -251,10 +246,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 6422,
+      "ms": 2600,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:27.351Z"
+      "timestamp": "2026-05-04T02:39:51.441Z"
     },
     {
       "path": "apps/simulations/gas-station-3am.html",
@@ -262,10 +257,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3233,
+      "ms": 2549,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:30.232Z"
+      "timestamp": "2026-05-04T02:38:55.378Z"
     },
     {
       "path": "apps/uncategorized/ant-farm-3d.html",
@@ -273,10 +268,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 4555,
+      "ms": 3558,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:31.389Z"
+      "timestamp": "2026-05-04T02:38:56.362Z"
     },
     {
       "path": "exhibitions/visual-arts/3d-particle-physics-simulator.html",
@@ -284,7 +279,7 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "fail",
-      "ms": 3201,
+      "ms": 2867,
       "errors": [
         {
           "kind": "http_404",
@@ -296,7 +291,7 @@
         }
       ],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:30.182Z"
+      "timestamp": "2026-05-04T02:38:55.740Z"
     },
     {
       "path": "v2/apps/creative_tools/acoustic-room-scanner.html",
@@ -304,10 +299,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2935,
+      "ms": 2601,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:29.859Z"
+      "timestamp": "2026-05-04T02:38:58.198Z"
     },
     {
       "path": "exhibitions/visual-arts/terminal-viewer.html",
@@ -315,10 +310,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3194,
+      "ms": 2604,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:33.193Z"
+      "timestamp": "2026-05-04T02:38:58.364Z"
     },
     {
       "path": "apps/ai-tools/agent-generator-ui.html",
@@ -326,26 +321,21 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3050,
+      "ms": 2544,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:33.188Z"
+      "timestamp": "2026-05-04T02:38:58.908Z"
     },
     {
       "path": "v2/apps/creative_tools/api-endpoint-tester.html",
       "title": "API Endpoint Tester",
       "category": "visual_art",
       "featured": true,
-      "verdict": "fail",
-      "ms": 3206,
-      "errors": [
-        {
-          "kind": "pageerror",
-          "msg": "Invalid left-hand side in assignment"
-        }
-      ],
+      "verdict": "pass",
+      "ms": 2707,
+      "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:30.215Z"
+      "timestamp": "2026-05-04T02:38:55.594Z"
     },
     {
       "path": "v86-master/examples/arch.html",
@@ -353,23 +343,23 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "fail",
-      "ms": 2991,
+      "ms": 2598,
       "errors": [
         {
           "kind": "console.error",
           "msg": "Failed to load resource: the server responded with a status of 404 (File not found)"
         },
         {
-          "kind": "pageerror",
-          "msg": "V86 is not defined"
+          "kind": "console.error",
+          "msg": "Loading the image ../images/fs.json failed (status %d) 404"
         },
         {
           "kind": "http_404",
-          "msg": "v86-master/build/libv86.js"
+          "msg": "v86-master/images/fs.json"
         }
       ],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:33.449Z"
+      "timestamp": "2026-05-04T02:39:00.651Z"
     },
     {
       "path": "apps/media/ascii-video-converter.html",
@@ -377,7 +367,7 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "fail",
-      "ms": 3049,
+      "ms": 2630,
       "errors": [
         {
           "kind": "console.error",
@@ -385,7 +375,7 @@
         }
       ],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:30.016Z"
+      "timestamp": "2026-05-04T02:38:58.048Z"
     },
     {
       "path": "apps/uncategorized/physics-lab.html",
@@ -393,10 +383,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3065,
+      "ms": 2540,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:33.541Z"
+      "timestamp": "2026-05-04T02:39:00.764Z"
     },
     {
       "path": "exhibitions/visual-arts/budget-tracker-expense-manager.html",
@@ -404,10 +394,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2768,
+      "ms": 2550,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:33.042Z"
+      "timestamp": "2026-05-04T02:39:00.924Z"
     },
     {
       "path": "exhibitions/visual-arts/canvas-svg-graphics-workshop.html",
@@ -415,10 +405,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3621,
+      "ms": 2537,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:36.778Z"
+      "timestamp": "2026-05-04T02:39:03.191Z"
     },
     {
       "path": "exhibitions/visual-arts/chart-builder-pro.html",
@@ -426,10 +416,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3510,
+      "ms": 2547,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:37.024Z"
+      "timestamp": "2026-05-04T02:39:03.313Z"
     },
     {
       "path": "exhibitions/visual-arts/claude-subagents-tutorial-continued.html",
@@ -437,10 +427,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3305,
+      "ms": 2543,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:36.735Z"
+      "timestamp": "2026-05-04T02:39:03.470Z"
     },
     {
       "path": "exhibitions/visual-arts/copilot-agent-365-tutorial.html",
@@ -448,10 +438,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2981,
+      "ms": 2542,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:36.490Z"
+      "timestamp": "2026-05-04T02:39:04.004Z"
     },
     {
       "path": "apps/productivity/crease-memory-theater.html",
@@ -459,10 +449,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2978,
+      "ms": 2432,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:36.736Z"
+      "timestamp": "2026-05-04T02:39:05.629Z"
     },
     {
       "path": "v2/apps/creative_tools/cyber-timer.html",
@@ -470,26 +460,21 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2145,
+      "ms": 2548,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:33.616Z"
+      "timestamp": "2026-05-04T02:39:01.459Z"
     },
     {
       "path": "exhibitions/visual-arts/data-structures-visualizer.html",
       "title": "Data Structures Visualizer",
       "category": "visual_art",
       "featured": true,
-      "verdict": "fail",
-      "ms": 3897,
-      "errors": [
-        {
-          "kind": "pageerror",
-          "msg": "Cannot access 'dataStructures' before initialization"
-        }
-      ],
+      "verdict": "pass",
+      "ms": 2310,
+      "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:37.694Z"
+      "timestamp": "2026-05-04T02:39:05.626Z"
     },
     {
       "path": "exhibitions/visual-arts/database-designer-erd.html",
@@ -497,10 +482,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3336,
+      "ms": 2538,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:39.831Z"
+      "timestamp": "2026-05-04T02:39:06.011Z"
     },
     {
       "path": "v2/apps/creative_tools/digital-twin-home.html",
@@ -508,10 +493,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3311,
+      "ms": 2542,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:40.171Z"
+      "timestamp": "2026-05-04T02:39:06.553Z"
     },
     {
       "path": "apps/games/doodle-to-world.html",
@@ -519,10 +504,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3312,
+      "ms": 2568,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:40.191Z"
+      "timestamp": "2026-05-04T02:39:08.197Z"
     },
     {
       "path": "exhibitions/visual-arts/presentation-slide-responsive-updated.html",
@@ -530,10 +515,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3257,
+      "ms": 2581,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:40.045Z"
+      "timestamp": "2026-05-04T02:39:08.240Z"
     },
     {
       "path": "v2/apps/creative_tools/exquisite-corpse-reactor.html",
@@ -541,10 +526,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2701,
+      "ms": 2555,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:39.744Z"
+      "timestamp": "2026-05-04T02:39:08.568Z"
     },
     {
       "path": "fluid-cathedral.html",
@@ -552,10 +537,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2350,
+      "ms": 3404,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:23.264Z"
+      "timestamp": "2026-05-04T02:39:52.455Z"
     },
     {
       "path": "exhibitions/visual-arts/fluid-dynamics-simulator.html",
@@ -563,10 +548,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2460,
+      "ms": 2542,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:40.440Z"
+      "timestamp": "2026-05-04T02:39:09.097Z"
     },
     {
       "path": "v2/apps/visual_art/fractal-os.html",
@@ -574,10 +559,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3562,
+      "ms": 2539,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:43.355Z"
+      "timestamp": "2026-05-04T02:39:10.738Z"
     },
     {
       "path": "apps/uncategorized/gene-wars.html",
@@ -585,10 +570,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2341,
+      "ms": 2542,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:42.177Z"
+      "timestamp": "2026-05-04T02:39:10.785Z"
     },
     {
       "path": "exhibitions/visual-arts/generative-art-studio.html",
@@ -596,10 +581,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3442,
+      "ms": 2539,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:43.744Z"
+      "timestamp": "2026-05-04T02:39:11.109Z"
     },
     {
       "path": "exhibitions/visual-arts/github-sync-manager.html",
@@ -607,10 +592,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3137,
+      "ms": 2544,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:43.400Z"
+      "timestamp": "2026-05-04T02:39:11.647Z"
     },
     {
       "path": "apps/uncategorized/gravity-well-sandbox.html",
@@ -618,10 +603,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3117,
+      "ms": 2539,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:43.416Z"
+      "timestamp": "2026-05-04T02:39:13.280Z"
     },
     {
       "path": "exhibitions/visual-arts/digit-recognition-wasm.html",
@@ -629,10 +614,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2640,
+      "ms": 2545,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:43.633Z"
+      "timestamp": "2026-05-04T02:39:13.880Z"
     },
     {
       "path": "apps/uncategorized/hourglass-choice.html",
@@ -640,10 +625,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2465,
+      "ms": 2542,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:45.350Z"
+      "timestamp": "2026-05-04T02:39:13.654Z"
     },
     {
       "path": "apps/uncategorized/imprint-erosion.html",
@@ -651,10 +636,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2796,
+      "ms": 2188,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:48.354Z"
+      "timestamp": "2026-05-04T02:39:13.837Z"
     },
     {
       "path": "v2/apps/creative_tools/infinite-os.html",
@@ -662,10 +647,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3376,
+      "ms": 2273,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:48.359Z"
+      "timestamp": "2026-05-04T02:39:16.831Z"
     },
     {
       "path": "exhibitions/visual-arts/copilot-agent-365-claude-code-installer.html",
@@ -673,26 +658,21 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3361,
+      "ms": 2216,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:48.378Z"
+      "timestamp": "2026-05-04T02:39:16.838Z"
     },
     {
       "path": "exhibitions/visual-arts/downloaded.html",
       "title": "LEVIATHAN: OMNIVERSE v10.9 - MOBILE OPTIMIZED",
       "category": "visual_art",
       "featured": true,
-      "verdict": "fail",
-      "ms": 12254,
-      "errors": [
-        {
-          "kind": "load_timeout",
-          "msg": "12000ms"
-        }
-      ],
+      "verdict": "pass",
+      "ms": 5796,
+      "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:55.938Z"
+      "timestamp": "2026-05-04T02:39:19.638Z"
     },
     {
       "path": "exhibitions/visual-arts/living-paint-dimension.html",
@@ -700,10 +680,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 4491,
+      "ms": 2519,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:49.907Z"
+      "timestamp": "2026-05-04T02:39:19.356Z"
     },
     {
       "path": "v2/apps/creative_tools/local-analytics-studio.html",
@@ -711,10 +691,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 5136,
+      "ms": 2512,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:53.530Z"
+      "timestamp": "2026-05-04T02:39:19.354Z"
     },
     {
       "path": "apps/uncategorized/local-first-starter-template.html",
@@ -722,10 +702,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 4200,
+      "ms": 2444,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:25.057Z"
+      "timestamp": "2026-05-04T02:39:50.687Z"
     },
     {
       "path": "my-agent-app/azure_function_app/index.html",
@@ -733,19 +713,19 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "fail",
-      "ms": 5138,
+      "ms": 2235,
       "errors": [
-        {
-          "kind": "http_501",
-          "msg": "api/businessinsightbot_function"
-        },
         {
           "kind": "console.error",
           "msg": "Failed to load resource: the server responded with a status of 501 (Unsupported method ('POST'))"
+        },
+        {
+          "kind": "http_501",
+          "msg": "api/businessinsightbot_function"
         }
       ],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:53.675Z"
+      "timestamp": "2026-05-04T02:39:20.583Z"
     },
     {
       "path": "exhibitions/visual-arts/localstorage-academy-tutorial.html",
@@ -753,10 +733,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 5120,
+      "ms": 2548,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:53.555Z"
+      "timestamp": "2026-05-04T02:39:21.914Z"
     },
     {
       "path": "exhibitions/visual-arts/severance-refiner.html",
@@ -764,26 +744,21 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 6104,
+      "ms": 4448,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:49.854Z"
+      "timestamp": "2026-05-04T02:39:18.336Z"
     },
     {
       "path": "apps/creative/magnetic-field-painter.html",
       "title": "Magnetic Field Painter",
       "category": "visual_art",
       "featured": true,
-      "verdict": "fail",
-      "ms": 3456,
-      "errors": [
-        {
-          "kind": "pageerror",
-          "msg": "Cannot access 'filings' before initialization"
-        }
-      ],
+      "verdict": "pass",
+      "ms": 2219,
+      "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:53.366Z"
+      "timestamp": "2026-05-04T02:39:21.581Z"
     },
     {
       "path": "v2/apps/creative_tools/meeting-cost-calculator.html",
@@ -791,10 +766,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2576,
+      "ms": 2519,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:52.549Z"
+      "timestamp": "2026-05-04T02:39:22.198Z"
     },
     {
       "path": "v2/apps/creative_tools/micro-os-generator.html",
@@ -802,10 +777,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2451,
+      "ms": 2329,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:55.004Z"
+      "timestamp": "2026-05-04T02:39:23.016Z"
     },
     {
       "path": "v2/apps/creative_tools/mind-palace-3d.html",
@@ -813,26 +788,21 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 4103,
+      "ms": 2368,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:57.489Z"
+      "timestamp": "2026-05-04T02:39:23.961Z"
     },
     {
       "path": "v2/apps/creative_tools/narrative-multiverse.html",
       "title": "Narrative Multiverse - Reality-Bending Collaborative Story Engine",
       "category": "visual_art",
       "featured": true,
-      "verdict": "fail",
-      "ms": 3934,
-      "errors": [
-        {
-          "kind": "pageerror",
-          "msg": "Unexpected end of input"
-        }
-      ],
+      "verdict": "pass",
+      "ms": 3423,
+      "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:57.483Z"
+      "timestamp": "2026-05-04T02:39:25.348Z"
     },
     {
       "path": "exhibitions/visual-arts/neural-network-playground.html",
@@ -840,10 +810,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3914,
+      "ms": 2755,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:57.499Z"
+      "timestamp": "2026-05-04T02:39:24.975Z"
     },
     {
       "path": "exhibitions/visual-arts/neural-network-zoo.html",
@@ -851,10 +821,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3793,
+      "ms": 2549,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:57.497Z"
+      "timestamp": "2026-05-04T02:39:25.606Z"
     },
     {
       "path": "exhibitions/visual-arts/nexus.html",
@@ -862,7 +832,7 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "fail",
-      "ms": 12120,
+      "ms": 8133,
       "errors": [
         {
           "kind": "console.error",
@@ -870,11 +840,11 @@
         },
         {
           "kind": "load_timeout",
-          "msg": "12000ms"
+          "msg": "8000ms"
         }
       ],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:07.206Z"
+      "timestamp": "2026-05-04T02:39:32.103Z"
     },
     {
       "path": "v2/apps/creative_tools/p2p-distributed-os.html",
@@ -882,10 +852,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2448,
+      "ms": 2336,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:11:58.419Z"
+      "timestamp": "2026-05-04T02:39:27.356Z"
     },
     {
       "path": "apps/uncategorized/palimpsest-engine.html",
@@ -893,10 +863,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2806,
+      "ms": 2561,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:00.417Z"
+      "timestamp": "2026-05-04T02:39:27.922Z"
     },
     {
       "path": "apps/simulations/particle-life-finance.html",
@@ -904,10 +874,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 4420,
+      "ms": 2550,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:01.958Z"
+      "timestamp": "2026-05-04T02:39:28.159Z"
     },
     {
       "path": "exhibitions/visual-arts/particle-life-simulator.html",
@@ -915,10 +885,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3080,
+      "ms": 2513,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:00.588Z"
+      "timestamp": "2026-05-04T02:39:29.877Z"
     },
     {
       "path": "exhibitions/visual-arts/particle-physics-playground.html",
@@ -926,10 +896,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2769,
+      "ms": 2569,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:00.282Z"
+      "timestamp": "2026-05-04T02:39:30.496Z"
     },
     {
       "path": "exhibitions/visual-arts/password-generator-strength-checker.html",
@@ -937,10 +907,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2574,
+      "ms": 2547,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:01.000Z"
+      "timestamp": "2026-05-04T02:39:30.729Z"
     },
     {
       "path": "apps/media/pendulum-wave.html",
@@ -948,10 +918,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 5677,
+      "ms": 2170,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:06.061Z"
+      "timestamp": "2026-05-04T02:39:32.054Z"
     },
     {
       "path": "apps/business/personal-finance-dashboard.html",
@@ -959,10 +929,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 6647,
+      "ms": 2547,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:07.224Z"
+      "timestamp": "2026-05-04T02:39:33.047Z"
     },
     {
       "path": "apps/creative/phosphor-pattern-painter.html",
@@ -970,10 +940,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2765,
+      "ms": 2549,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:03.577Z"
+      "timestamp": "2026-05-04T02:39:33.321Z"
     },
     {
       "path": "photobooth-fx.html",
@@ -981,10 +951,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 6576,
+      "ms": 2714,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:29.967Z"
+      "timestamp": "2026-05-04T02:39:51.857Z"
     },
     {
       "path": "exhibitions/visual-arts/physics-playground-lab.html",
@@ -992,10 +962,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2753,
+      "ms": 2556,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:04.063Z"
+      "timestamp": "2026-05-04T02:39:34.636Z"
     },
     {
       "path": "apps/uncategorized/pigment-stratigraphics.html",
@@ -1003,10 +973,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3170,
+      "ms": 2186,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:05.345Z"
+      "timestamp": "2026-05-04T02:39:34.293Z"
     },
     {
       "path": "exhibitions/visual-arts/pipboy-interface.html",
@@ -1014,7 +984,7 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "fail",
-      "ms": 12877,
+      "ms": 8057,
       "errors": [
         {
           "kind": "console.error",
@@ -1022,11 +992,11 @@
         },
         {
           "kind": "load_timeout",
-          "msg": "12000ms"
+          "msg": "8000ms"
         }
       ],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:16.750Z"
+      "timestamp": "2026-05-04T02:39:41.131Z"
     },
     {
       "path": "apps/uncategorized/prism-refract.html",
@@ -1034,10 +1004,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2968,
+      "ms": 2282,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:07.145Z"
+      "timestamp": "2026-05-04T02:39:35.617Z"
     },
     {
       "path": "exhibitions/visual-arts/prompt-architect.html",
@@ -1045,10 +1015,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2676,
+      "ms": 2547,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:08.110Z"
+      "timestamp": "2026-05-04T02:39:36.865Z"
     },
     {
       "path": "exhibitions/visual-arts/quantum-circuit-designer.html",
@@ -1056,10 +1026,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3299,
+      "ms": 2578,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:09.386Z"
+      "timestamp": "2026-05-04T02:39:37.242Z"
     },
     {
       "path": "exhibitions/visual-arts/quantum-particle-lab.html",
@@ -1067,10 +1037,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3266,
+      "ms": 2551,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:10.483Z"
+      "timestamp": "2026-05-04T02:39:38.175Z"
     },
     {
       "path": "exhibitions/visual-arts/quantum-vm-threejs.html",
@@ -1078,10 +1048,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 6238,
+      "ms": 2577,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:13.617Z"
+      "timestamp": "2026-05-04T02:39:39.453Z"
     },
     {
       "path": "exhibitions/visual-arts/rainbow-svg-path.html",
@@ -1089,10 +1059,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3852,
+      "ms": 2490,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:11.106Z"
+      "timestamp": "2026-05-04T02:39:39.740Z"
     },
     {
       "path": "apps/uncategorized/recursive-dream-studio.html",
@@ -1100,10 +1070,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 3235,
+      "ms": 2552,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:11.436Z"
+      "timestamp": "2026-05-04T02:39:40.754Z"
     },
     {
       "path": "apps/uncategorized/shadow-story-automaton.html",
@@ -1111,10 +1081,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2873,
+      "ms": 2725,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:12.264Z"
+      "timestamp": "2026-05-04T02:39:42.194Z"
     },
     {
       "path": "apps/uncategorized/surface-tension.html",
@@ -1122,10 +1092,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2973,
+      "ms": 2568,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:13.528Z"
+      "timestamp": "2026-05-04T02:39:42.314Z"
     },
     {
       "path": "v86-master/examples/tcp_terminal.html",
@@ -1133,23 +1103,23 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "fail",
-      "ms": 2711,
+      "ms": 2618,
       "errors": [
-        {
-          "kind": "http_404",
-          "msg": "v86-master/build/libv86.js"
-        },
         {
           "kind": "console.error",
           "msg": "Failed to load resource: the server responded with a status of 404 (File not found)"
         },
         {
-          "kind": "pageerror",
-          "msg": "V86 is not defined"
+          "kind": "console.error",
+          "msg": "Loading the image ../images/buildroot-bzimage68.bin failed (status %d) 404"
+        },
+        {
+          "kind": "http_404",
+          "msg": "v86-master/images/buildroot-bzimage68.bin"
         }
       ],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:15.179Z"
+      "timestamp": "2026-05-04T02:39:43.424Z"
     },
     {
       "path": "exhibitions/visual-arts/teacher-learner-app.html",
@@ -1157,10 +1127,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2694,
+      "ms": 2242,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:15.225Z"
+      "timestamp": "2026-05-04T02:39:43.430Z"
     },
     {
       "path": "apps/uncategorized/akashic-library.html",
@@ -1168,10 +1138,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 2493,
+      "ms": 2923,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:15.283Z"
+      "timestamp": "2026-05-04T02:39:45.196Z"
     },
     {
       "path": "apps/uncategorized/forgetting-machine.html",
@@ -1179,10 +1149,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 6389,
+      "ms": 2582,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:20.117Z"
+      "timestamp": "2026-05-04T02:39:44.950Z"
     },
     {
       "path": "apps/games/infinite-card-catalog.html",
@@ -1190,10 +1160,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 6428,
+      "ms": 2665,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:20.185Z"
+      "timestamp": "2026-05-04T02:39:46.311Z"
     },
     {
       "path": "v2/apps/creative_tools/timezone-meeting-planner.html",
@@ -1201,26 +1171,21 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 5677,
+      "ms": 2588,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:20.867Z"
+      "timestamp": "2026-05-04T02:39:46.091Z"
     },
     {
       "path": "v2/apps/creative_tools/time-travel-editor.html",
       "title": "Time-Travel Code Editor (4D)",
       "category": "visual_art",
       "featured": true,
-      "verdict": "fail",
-      "ms": 9160,
-      "errors": [
-        {
-          "kind": "pageerror",
-          "msg": "THREE.CapsuleGeometry is not a constructor"
-        }
-      ],
+      "verdict": "pass",
+      "ms": 3827,
+      "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:25.043Z"
+      "timestamp": "2026-05-04T02:39:48.800Z"
     },
     {
       "path": "exhibitions/visual-arts/vector-drawing-studio.html",
@@ -1228,10 +1193,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 8801,
+      "ms": 2723,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:24.333Z"
+      "timestamp": "2026-05-04T02:39:47.933Z"
     },
     {
       "path": "v2/apps/creative_tools/windows95-emulator.html",
@@ -1239,19 +1204,19 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "fail",
-      "ms": 3971,
+      "ms": 2968,
       "errors": [
-        {
-          "kind": "console.error",
-          "msg": "Failed to load resource: the server responded with a status of 404 (File not found)"
-        },
-        {
-          "kind": "console.error",
-          "msg": "Failed to load resource: the server responded with a status of 404 (File not found)"
-        },
         {
           "kind": "http_404",
           "msg": "v2/apps/creative_tools/.ai/windows95-agent-state.json"
+        },
+        {
+          "kind": "console.error",
+          "msg": "Failed to load resource: the server responded with a status of 404 (File not found)"
+        },
+        {
+          "kind": "console.error",
+          "msg": "Failed to load resource: the server responded with a status of 404 (File not found)"
         },
         {
           "kind": "http_404",
@@ -1259,7 +1224,7 @@
         }
       ],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:20.782Z"
+      "timestamp": "2026-05-04T02:39:49.119Z"
     },
     {
       "path": "exhibitions/visual-arts/youtube-webcam-sync-fixed.html",
@@ -1267,10 +1232,10 @@
       "category": "visual_art",
       "featured": true,
       "verdict": "pass",
-      "ms": 8696,
+      "ms": 2622,
       "errors": [],
       "warnings": [],
-      "timestamp": "2026-05-04T02:12:28.882Z"
+      "timestamp": "2026-05-04T02:39:49.003Z"
     }
   ]
 }

--- a/data/reports/health-check-latest.md
+++ b/data/reports/health-check-latest.md
@@ -1,44 +1,36 @@
 # Health Check Report
 
-_Generated: 2026-05-04T02:12:42.735Z_
+_Generated: 2026-05-04T02:40:06.266Z_
 
 - **Total**: 100
-- **Pass**: 85 (85.0%)
-- **Fail**: 15
-- **Avg load time**: 4211ms
+- **Pass**: 92 (92.0%)
+- **Fail**: 8
+- **Avg load time**: 2784ms
 
 ## Failing apps
 
 | App | Errors |
 |---|---|
-| [`exhibitions/simulation-lab/3d-engine-v8-modular.html`](https://kody-w.github.io/localFirstTools/exhibitions/simulation-lab/3d-engine-v8-modular.html) | `pageerror` obj.mesh.quaternion.copy is not a function
-http://localhost:8765/exhibitions/sim |
 | [`exhibitions/visual-arts/3d-particle-physics-simulator.html`](https://kody-w.github.io/localFirstTools/exhibitions/visual-arts/3d-particle-physics-simulator.html) | `http_404` favicon.ico<br>`console.error` Failed to load resource: the server responded with a status of 404 (File not fou |
-| [`v2/apps/creative_tools/api-endpoint-tester.html`](https://kody-w.github.io/localFirstTools/v2/apps/creative_tools/api-endpoint-tester.html) | `pageerror` Invalid left-hand side in assignment |
-| [`v86-master/examples/arch.html`](https://kody-w.github.io/localFirstTools/v86-master/examples/arch.html) | `console.error` Failed to load resource: the server responded with a status of 404 (File not fou<br>`pageerror` V86 is not defined |
+| [`v86-master/examples/arch.html`](https://kody-w.github.io/localFirstTools/v86-master/examples/arch.html) | `console.error` Failed to load resource: the server responded with a status of 404 (File not fou<br>`console.error` Loading the image ../images/fs.json failed (status %d) 404 |
 | [`apps/media/ascii-video-converter.html`](https://kody-w.github.io/localFirstTools/apps/media/ascii-video-converter.html) | `console.error` Camera error: NotAllowedError: Permission denied |
-| [`exhibitions/visual-arts/data-structures-visualizer.html`](https://kody-w.github.io/localFirstTools/exhibitions/visual-arts/data-structures-visualizer.html) | `pageerror` Cannot access 'dataStructures' before initialization |
-| [`exhibitions/visual-arts/downloaded.html`](https://kody-w.github.io/localFirstTools/exhibitions/visual-arts/downloaded.html) | `load_timeout` 12000ms |
-| [`my-agent-app/azure_function_app/index.html`](https://kody-w.github.io/localFirstTools/my-agent-app/azure_function_app/index.html) | `http_501` api/businessinsightbot_function<br>`console.error` Failed to load resource: the server responded with a status of 501 (Unsupported  |
-| [`apps/creative/magnetic-field-painter.html`](https://kody-w.github.io/localFirstTools/apps/creative/magnetic-field-painter.html) | `pageerror` Cannot access 'filings' before initialization |
-| [`v2/apps/creative_tools/narrative-multiverse.html`](https://kody-w.github.io/localFirstTools/v2/apps/creative_tools/narrative-multiverse.html) | `pageerror` Unexpected end of input |
-| [`exhibitions/visual-arts/nexus.html`](https://kody-w.github.io/localFirstTools/exhibitions/visual-arts/nexus.html) | `console.error` Failed to acquire camera feed: NotAllowedError: Permission denied<br>`load_timeout` 12000ms |
-| [`exhibitions/visual-arts/pipboy-interface.html`](https://kody-w.github.io/localFirstTools/exhibitions/visual-arts/pipboy-interface.html) | `console.error` Failed to acquire camera feed: NotAllowedError: Permission denied<br>`load_timeout` 12000ms |
-| [`v86-master/examples/tcp_terminal.html`](https://kody-w.github.io/localFirstTools/v86-master/examples/tcp_terminal.html) | `http_404` v86-master/build/libv86.js<br>`console.error` Failed to load resource: the server responded with a status of 404 (File not fou |
-| [`v2/apps/creative_tools/time-travel-editor.html`](https://kody-w.github.io/localFirstTools/v2/apps/creative_tools/time-travel-editor.html) | `pageerror` THREE.CapsuleGeometry is not a constructor |
-| [`v2/apps/creative_tools/windows95-emulator.html`](https://kody-w.github.io/localFirstTools/v2/apps/creative_tools/windows95-emulator.html) | `console.error` Failed to load resource: the server responded with a status of 404 (File not fou<br>`console.error` Failed to load resource: the server responded with a status of 404 (File not fou |
+| [`my-agent-app/azure_function_app/index.html`](https://kody-w.github.io/localFirstTools/my-agent-app/azure_function_app/index.html) | `console.error` Failed to load resource: the server responded with a status of 501 (Unsupported <br>`http_501` api/businessinsightbot_function |
+| [`exhibitions/visual-arts/nexus.html`](https://kody-w.github.io/localFirstTools/exhibitions/visual-arts/nexus.html) | `console.error` Failed to acquire camera feed: NotAllowedError: Permission denied<br>`load_timeout` 8000ms |
+| [`exhibitions/visual-arts/pipboy-interface.html`](https://kody-w.github.io/localFirstTools/exhibitions/visual-arts/pipboy-interface.html) | `console.error` Failed to acquire camera feed: NotAllowedError: Permission denied<br>`load_timeout` 8000ms |
+| [`v86-master/examples/tcp_terminal.html`](https://kody-w.github.io/localFirstTools/v86-master/examples/tcp_terminal.html) | `console.error` Failed to load resource: the server responded with a status of 404 (File not fou<br>`console.error` Loading the image ../images/buildroot-bzimage68.bin failed (status %d) 404 |
+| [`v2/apps/creative_tools/windows95-emulator.html`](https://kody-w.github.io/localFirstTools/v2/apps/creative_tools/windows95-emulator.html) | `http_404` v2/apps/creative_tools/.ai/windows95-agent-state.json<br>`console.error` Failed to load resource: the server responded with a status of 404 (File not fou |
 
 ## 10 slowest loads
 
 | App | ms |
 |---|---|
-| `exhibitions/visual-arts/pipboy-interface.html` | 12877 |
-| `exhibitions/visual-arts/downloaded.html` | 12254 |
-| `exhibitions/visual-arts/nexus.html` | 12120 |
-| `v2/apps/creative_tools/time-travel-editor.html` | 9160 |
-| `exhibitions/visual-arts/vector-drawing-studio.html` | 8801 |
-| `exhibitions/visual-arts/youtube-webcam-sync-fixed.html` | 8696 |
-| `apps/simulations/ant-farm-simulation.html` | 7692 |
-| `apps/business/personal-finance-dashboard.html` | 6647 |
-| `exhibitions/simulation-lab/tile-room-3d.html` | 6641 |
-| `exhibitions/simulation-lab/workshop.html` | 6614 |
+| `exhibitions/visual-arts/nexus.html` | 8133 |
+| `exhibitions/visual-arts/pipboy-interface.html` | 8057 |
+| `exhibitions/visual-arts/downloaded.html` | 5796 |
+| `exhibitions/simulation-lab/index_slim_cloud.html` | 4776 |
+| `exhibitions/visual-arts/severance-refiner.html` | 4448 |
+| `v2/apps/creative_tools/time-travel-editor.html` | 3827 |
+| `exhibitions/simulation-lab/workshop.html` | 3813 |
+| `apps/uncategorized/ant-farm-3d.html` | 3558 |
+| `v2/apps/creative_tools/narrative-multiverse.html` | 3423 |
+| `fluid-cathedral.html` | 3404 |

--- a/node_modules/puppeteer
+++ b/node_modules/puppeteer
@@ -1,1 +1,0 @@
-/tmp/node_modules/puppeteer

--- a/node_modules/puppeteer
+++ b/node_modules/puppeteer
@@ -1,0 +1,1 @@
+/tmp/node_modules/puppeteer

--- a/sky-realms-game.html
+++ b/sky-realms-game.html
@@ -7193,13 +7193,13 @@
                 }
 
                 // v1.28.0: Update ARIA label with tier info
-                const tierName = COMBO_TIER_NAMES[currentTier - 1];
-                const ariaLabel = `Combo Tier ${currentTier} of 5: ${tierName}. ${STATE.comboKills} kills, ${STATE.comboMultiplier}x multiplier`;
+                const currentTierName = COMBO_TIER_NAMES[currentTier - 1];
+                const ariaLabel = `Combo Tier ${currentTier} of 5: ${currentTierName}. ${STATE.comboKills} kills, ${STATE.comboMultiplier}x multiplier`;
                 DOM_CACHE.comboDisplay.setAttribute('aria-label', ariaLabel);
 
                 // v1.28.0: Announce tier progression to screen readers
                 if (currentTier > STATE.lastAnnouncedComboTier && DOM_CACHE.ariaAlertRegion) {
-                    DOM_CACHE.ariaAlertRegion.textContent = `Combo tier up! Now at ${tierName} tier, ${currentTier} of 5`;
+                    DOM_CACHE.ariaAlertRegion.textContent = `Combo tier up! Now at ${currentTierName} tier, ${currentTier} of 5`;
                     STATE.lastAnnouncedComboTier = currentTier;
 
                     // v1.31.0: Combo Tier Ring Pulse (UX Polish Specialist)

--- a/submarine-240m.html
+++ b/submarine-240m.html
@@ -1004,6 +1004,23 @@ function paintGauge(g) {
   ctx.beginPath(); ctx.arc(128,128,10,0,Math.PI*2); ctx.fillStyle = '#222'; ctx.fill();
   g.tex.needsUpdate = true;
 }
+// =========================================================================
+//  STATE
+// =========================================================================
+const state = {
+  depth: 240,
+  targetDepth: 240,
+  heading: 0,
+  oxygen: 98.4,
+  pressure: 25.1,
+  startTime: performance.now(),
+  flickerUntil: 0,
+  pingTimer: 0,
+  pingInterval: 4.0,
+  periscope: false,
+  zoom: 1.0,
+};
+
 const gauges = [
   { ...makeGaugeTexture('DEPTH', () => state.depth/500), pos: [1.1, 0.05, -1.7] },
   { ...makeGaugeTexture('PRESS', () => state.pressure/55), pos: [1.1, 0.45, -2.0] },
@@ -1218,22 +1235,6 @@ function playWhale() {
   osc.start(t); osc.stop(t + dur + 0.1);
 }
 
-// =========================================================================
-//  STATE
-// =========================================================================
-const state = {
-  depth: 240,
-  targetDepth: 240,
-  heading: 0,
-  oxygen: 98.4,
-  pressure: 25.1,
-  startTime: performance.now(),
-  flickerUntil: 0,
-  pingTimer: 0,
-  pingInterval: 4.0,
-  periscope: false,
-  zoom: 1.0,
-};
 
 function triggerFlicker() {
   state.flickerUntil = performance.now() + 280 + Math.random()*220;

--- a/v2/apps/creative_tools/time-travel-editor.html
+++ b/v2/apps/creative_tools/time-travel-editor.html
@@ -314,7 +314,7 @@
 <html>
 <head>
     <title>Stage 2: 3D Setup</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r150/three.min.js"><\/script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.150.0/build/three.min.js"><\/script>
     <style>body { margin: 0; overflow: hidden; }</style>
 </head>
 <body>
@@ -349,7 +349,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PalBoids 3D: Swarm Collector</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r150/three.min.js"><\/script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.150.0/build/three.min.js"><\/script>
     <style>
         body { margin: 0; overflow: hidden; background-color: #0f172a; font-family: sans-serif; color: #e2e8f0; user-select: none; }
         #ui-layer { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }

--- a/v2/apps/visual_art/data-structures-visualizer.html
+++ b/v2/apps/visual_art/data-structures-visualizer.html
@@ -144,7 +144,7 @@
             canvas.height = canvas.parentElement.clientHeight;
             render();
         }
-        resize();
+        // (initial resize() deferred until after dataStructures const init — was TDZ-broken)
         window.addEventListener('resize', resize);
 
         const dataStructures = {
@@ -398,6 +398,9 @@
                 }
             }
         };
+
+        // Now safe to call — dataStructures is initialized
+        resize();
 
         function render() {
             dataStructures[currentDS].draw();

--- a/v86-master/examples/alpine.html
+++ b/v86-master/examples/alpine.html
@@ -1,17 +1,17 @@
 <!doctype html>
 <title>Alpine</title>
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 window.onload = function()
 {
     var emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 512 * 1024 * 1024,
         vga_memory_size: 8 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
-        bios: { url: "../bios/seabios.bin" },
-        vga_bios: { url: "../bios/vgabios.bin" },
+        bios: { url: "/v86/bios/seabios.bin" },
+        vga_bios: { url: "/v86/bios/vgabios.bin" },
         filesystem: {
             baseurl: "../images/alpine-rootfs-flat",
             basefs: "../images/alpine-fs.json",

--- a/v86-master/examples/arch.html
+++ b/v86-master/examples/arch.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <title>Archlinux</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
 window.onload = function()
 {
     var emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 512 * 1024 * 1024,
         vga_memory_size: 8 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         filesystem: {
             baseurl: "../images/arch/",

--- a/v86-master/examples/async_load.html
+++ b/v86-master/examples/async_load.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>Asynchronous loading of disk images</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
@@ -14,15 +14,15 @@ window.onload = function()
     // is required if the server is on a different host
 
     var emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 64 * 1024 * 1024,
         vga_memory_size: 2 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         cdrom: {
             url: "../images/dsl-4.11.rc2.iso",

--- a/v86-master/examples/basic.html
+++ b/v86-master/examples/basic.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <title>Basic Emulator</title><!-- not BASIC! -->
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
 window.onload = function()
 {
     var emulator = window.emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 32 * 1024 * 1024,
         vga_memory_size: 2 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         cdrom: {
             url: "../images/linux.iso",

--- a/v86-master/examples/broadcast-network.html
+++ b/v86-master/examples/broadcast-network.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <title>Networking via Broadcast Channel API</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
 window.onload = function()
 {
     var emulator = window.emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 64 * 1024 * 1024,
         vga_memory_size: 2 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         bzimage: {
             url: "../images/buildroot-bzimage68.bin",

--- a/v86-master/examples/destroy.html
+++ b/v86-master/examples/destroy.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <title>Destroyable Emulator</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
 window.onload = function()
 {
     var emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 32 * 1024 * 1024,
         vga_memory_size: 2 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         cdrom: {
             url: "../images/linux.iso",

--- a/v86-master/examples/lang.html
+++ b/v86-master/examples/lang.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>Basic Emulator</title><!-- not BASIC! -->
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
@@ -15,15 +15,15 @@ window.onload = function()
     }, 999);
 
     var emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 512 * 1024 * 1024,
         vga_memory_size: 8 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         initial_state: {
             url: "../images/arch_state-v2.bin.zst",

--- a/v86-master/examples/lua.html
+++ b/v86-master/examples/lua.html
@@ -1,14 +1,14 @@
 <!doctype html>
 <title>Lua interpreter</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
 window.onload = function()
 {
     var emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 32 * 1024 * 1024,
         vga_memory_size: 2 * 1024 * 1024,
 
@@ -16,10 +16,10 @@ window.onload = function()
         //screen_container: document.getElementById("screen_container"),
 
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         bzimage: {
             url: "../images/buildroot-bzimage68.bin",

--- a/v86-master/examples/save_restore.html
+++ b/v86-master/examples/save_restore.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <title>Save and restore</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
 window.onload = function()
 {
     var emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 32 * 1024 * 1024,
         vga_memory_size: 2 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         cdrom: {
             url: "../images/linux.iso",

--- a/v86-master/examples/sectorc.html
+++ b/v86-master/examples/sectorc.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>v86: sectorc</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
@@ -651,12 +651,12 @@ void main()
         emulator && emulator.destroy();
 
         emulator = window.emulator = new V86({
-            wasm_path: "../build/v86.wasm",
+            wasm_path: "/v86/build/v86.wasm",
             memory_size: 32 * 1024 * 1024,
             vga_memory_size: 2 * 1024 * 1024,
             screen_container: document.getElementById("screen_container"),
-            bios: { url: "../bios/seabios.bin" },
-            vga_bios: { url: "../bios/vgabios.bin" },
+            bios: { url: "/v86/bios/seabios.bin" },
+            vga_bios: { url: "/v86/bios/vgabios.bin" },
             fda: { url: "../images/sectorc.bin" },
             autostart: true,
         });

--- a/v86-master/examples/serial.html
+++ b/v86-master/examples/serial.html
@@ -1,23 +1,23 @@
 <!doctype html>
 <title>Serial example</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
 window.onload = function()
 {
     var emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
 
         // Uncomment to see what's going on
         //screen_container: document.getElementById("screen_container"),
 
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         bzimage: {
             url: "../images/buildroot-bzimage68.bin",

--- a/v86-master/examples/tcp_terminal.html
+++ b/v86-master/examples/tcp_terminal.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <title>TCP Terminal</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
 window.onload = function()
 {
     var emulator = window.emulator = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         memory_size: 64 * 1024 * 1024,
         vga_memory_size: 2 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         bzimage: {
             url: "../images/buildroot-bzimage68.bin",

--- a/v86-master/examples/two_instances.html
+++ b/v86-master/examples/two_instances.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <title>Two emulators</title>
 
-<script src="../build/libv86.js"></script>
+<script src="/v86/build/libv86.js"></script>
 <script>
 "use strict";
 
@@ -11,13 +11,13 @@ window.onload = function()
     var container2 = document.getElementById("screen_container2");
 
     var emulator1 = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         screen_container: container1,
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         cdrom: {
             url: "../images/linux4.iso",
@@ -26,13 +26,13 @@ window.onload = function()
     });
 
     var emulator2 = new V86({
-        wasm_path: "../build/v86.wasm",
+        wasm_path: "/v86/build/v86.wasm",
         screen_container: container2,
         bios: {
-            url: "../bios/seabios.bin",
+            url: "/v86/bios/seabios.bin",
         },
         vga_bios: {
-            url: "../bios/vgabios.bin",
+            url: "/v86/bios/vgabios.bin",
         },
         cdrom: {
             url: "../images/linux4.iso",


### PR DESCRIPTION
**Overnight pass 4.** Health-check harness from PR #21 ran on 200 featured apps and surfaced 26 failures. This PR fixes 9 of them across 8 bug classes.

## Pass rate

**85% → 92%** (100-app baseline). 15 → 8 failing apps in the latest report.

The 8 remaining failures are mostly camera-permission denials in headless Chrome (which fail-open in real browsers when user grants permission) + one app needing a missing API endpoint.

## Bugs fixed

| Bug | App(s) | Fix |
|---|---|---|
| `V86 is not defined` / 404 on `libv86.js` | 13 v86-master/examples files | Rewrote relative `../build/` paths to absolute `/v86/build/` (where artifacts actually live) |
| TDZ `Cannot access dataStructures` | apps/uncategorized + v2/apps/visual_art data-structures-visualizer | Defer `resize()` until after const init |
| `THREE is not defined` / `CapsuleGeometry not a constructor` | apps/development + v2/apps/creative_tools time-travel-editor | **PR #21 fix was wrong** — bumped to r150 on cdnjs but cdnjs only has r128. Switched to jsdelivr where 0.150.0 actually exists |
| `FRAME_BUFFER_SIZE` + `frameBuffers` + `frameTextures` + `frameIndex` undeclared | apps/utilities/bothangles-ios-fixed | Added declarations + dynamic canvas creation when DOM canvases missing |
| Duplicate `const tierName` in same scope | sky-realms-game | Renamed second to `currentTierName` |
| TDZ `Cannot access cols` | apps/creative/dune-symphony | Moved const above resize() |
| TDZ `Cannot access Filing` (class) | apps/creative/magnetic-field-painter | JS classes aren't hoisted — deferred resize() to after class decl |
| TDZ `Cannot access state` | submarine-240m | Moved `const state {…}` above `const gauges = […]` (which had closures touching state when paintGauge ran immediately) |

All 8 file groups verified passing via headless puppeteer.

Updated `data/reports/health-check-latest.{json,md}` with the new 100-app baseline (92% pass).

The bugs followed clear patterns: (1) **TDZ** when top-level resize/init calls reference values declared further down — 4 instances in this batch alone, suggesting it's worth a lint rule. (2) **CDN typos** that worked at write-time but the version vanished. (3) **Undeclared globals** that didn't fail in browsers with permissive runtime modes.

Auto-merging.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>